### PR TITLE
QA: Final

### DIFF
--- a/src/components/logos/hydro.html
+++ b/src/components/logos/hydro.html
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73.81 27.15">
+<svg width="100%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73.81 27.15">
   <g fill="currentColor">
     <g>
       <path

--- a/src/components/logos/light.html
+++ b/src/components/logos/light.html
@@ -1,9 +1,4 @@
-<svg
-  viewBox="0 0 75 36"
-  version="1.1"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
->
+<svg width="100%" viewBox="0 0 75 36" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <desc>The Light Phone Logo</desc>
   <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
     <g id="Light-Logo-Gray" fill="currentColor">

--- a/src/components/product-grid.html
+++ b/src/components/product-grid.html
@@ -1,121 +1,121 @@
 <div class="ProductGrid">
   <a
-    class="ProductGrid__item text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item box-glow flex items-center justify-center py1 text-center"
     href="https://www.xxix.co/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-6">
+    <span class="flex items-center justify-center col-5">
       <include src="./components/logos/xxix.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item sanctu text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item sanctu box-glow flex items-center justify-center py1 text-center"
     href="https://www.sanctuary.computer/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-7">
+    <span class="flex items-center justify-center col-5">
       <include src="./components/logos/sanctu-compu.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item box-glow flex items-center justify-center py1 text-center"
     href="https://hydraulics.nyc/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-7">
+    <span class="flex items-center justify-center col-6">
       <include src="./components/logos/hydro.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item seaborne text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item seaborne box-glow flex items-center justify-center py1 text-center"
     href="https://www.seaborne.nyc/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-8">
+    <span class="flex items-center justify-center col-6">
       <include src="./components/logos/seaborne.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item index text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item index box-glow flex items-center justify-center py1 text-center"
     href="https://www.index-space.org/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-6">
+    <span class="flex items-center justify-center col-4">
       <include src="./components/logos/index.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item light text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item light box-glow flex items-center justify-center py1 text-center"
     href="https://www.thelightphone.com/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-6">
+    <span class="flex items-center justify-center col-4">
       <include src="./components/logos/light.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item box-glow flex items-center justify-center py1 text-center"
     href="https://www.opentender.io/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/open-tender.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item box-glow flex items-center justify-center py1 text-center"
     href="https://www.spirit.fish/"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/spirit-fish.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item box-glow flex items-center justify-center py1 text-center"
     href="https://twitter.com/_HHFF"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/your-company.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item serif text-small text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item serif text-small box-glow flex items-center justify-center py1 text-center"
     href="https://twitter.com/_HHFF"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/your-company.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item serif text-small text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item serif text-small box-glow flex items-center justify-center py1 text-center"
     href="https://twitter.com/_HHFF"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/your-company.html"></include>
     </span>
   </a>
   <a
-    class="ProductGrid__item serif text-small text-glow--hover flex items-center justify-center py1 text-center"
+    class="ProductGrid__item serif text-small box-glow flex items-center justify-center py1 text-center"
     href="https://twitter.com/_HHFF"
     target="_blank"
     rel="noopener"
   >
-    <span class="flex items-center justify-center col-10">
+    <span class="flex items-center justify-center col-8">
       <include src="./components/logos/your-company.html"></include>
     </span>
   </a>

--- a/src/index.html
+++ b/src/index.html
@@ -8,9 +8,9 @@
 
       <div
         id="Content"
-        class="Content text-body sans-serif text-glow justify-between xs:justify-start hauto xs:hauto sm:flex sm:flex-row pb1 sm:pb0"
+        class="Content text-body sans-serif text-glow justify-between xs:justify-start hauto xs:hauto lg:flex lg:flex-row pb1 lg:pb0"
       >
-        <div class="Content__info flex flex-col sm:flex-row col-12 sm:col-6 mb6_25 sm:mb0">
+        <div class="Content__info flex flex-col sm:flex-row col-12 lg:col-6 mb6_25 lg:mb0">
           <div class="sm:pr_625">
             <p class="mb1_25 md:flex">
               <span class="Garden3d">
@@ -179,7 +179,7 @@
             </div>
           </div>
         </div>
-        <div class="Content__product-grid block col-12 sm:col-6 sm:pl_625 pb1 xs:pb0">
+        <div class="Content__product-grid block col-12 lg:col-6 lg:pl_625 pb1 xs:pb0">
           <include src="./components/product-grid.html"></include>
         </div>
       </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,31 +6,43 @@ import fav from './fav';
 
 import { Theme } from './constants';
 
+const setThemeEvil = () => {
+  document.documentElement.setAttribute('data-theme', Theme.EVIL);
+  fav.makeEvil();
+  shimmer.makeEvil();
+  audio.makeEvil();
+  background.makeEvil();
+};
+
+const setThemeGood = () => {
+  document.documentElement.setAttribute('data-theme', Theme.GOOD);
+  fav.makeGood();
+  shimmer.makeGood();
+  audio.makeGood();
+  background.makeGood();
+};
+
+// Theme toggle
 const themeToggle = document.querySelector('[data-trigger="theme-toggle"]');
 
 const handleToggleTheme = function () {
   const activeTheme = document.documentElement.getAttribute('data-theme');
 
   if (activeTheme === Theme.GOOD) {
-    document.documentElement.setAttribute('data-theme', Theme.EVIL);
-    fav.makeEvil();
-    shimmer.makeEvil();
-    audio.makeEvil();
-    background.makeEvil();
+    setThemeEvil();
   } else {
-    document.documentElement.setAttribute('data-theme', Theme.GOOD);
-    fav.makeGood();
-    shimmer.makeGood();
-    audio.makeGood();
-    background.makeGood();
+    setThemeGood();
   }
 };
 
+themeToggle.addEventListener('click', handleToggleTheme);
+
+// Init
 (() => {
   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    document.documentElement.setAttribute('data-theme', Theme.EVIL);
+    setThemeEvil();
   } else {
-    document.documentElement.setAttribute('data-theme', Theme.GOOD);
+    setThemeGood();
   }
 
   const Hero = document.getElementById('Hero');
@@ -39,8 +51,6 @@ const handleToggleTheme = function () {
   Hero.classList.add('Hero--active');
   Content.classList.add('Content--active');
 })();
-
-themeToggle.addEventListener('click', handleToggleTheme);
 
 /** Credit Alex Bainter */
 

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -13,8 +13,9 @@ $spacing-units: 0rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem,
 
 $breakpoints: (
   'xs': 375px,
-  'sm': 834px,
-  'md': 1280px,
-  'lg': 1680px,
-  'xl': 1920px,
+  'sm': 640px,
+  'md': 768px,
+  'lg': 1024px,
+  'xl': 1280px,
+  'xxl': 1536px,
 );

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -26,12 +26,16 @@
   --background-color: #{color('dark')};
 }
 
-.text-glow {
-  text-shadow: 0 0 5px var(--text-color);
+.box-glow {
+  box-shadow: 0 0 3px var(--fill-color);
 }
 
-.text-glow--hover {
-  &:hover {
-    text-shadow: 0 0 5px var(--hover-text-color);
+.text-glow {
+  text-shadow: 0 0 5px var(--text-color);
+
+  &--hover {
+    &:hover {
+      text-shadow: 0 0 5px var(--hover-text-color);
+    }
   }
 }

--- a/src/scss/components/hero.scss
+++ b/src/scss/components/hero.scss
@@ -10,10 +10,10 @@
 
   &__audio {
     position: absolute;
-    bottom: -50px;
-    right: 0px;
+    bottom: 0;
+    right: 0;
 
-    @include media('md-up') {
+    @include media('xl-up') {
       bottom: auto;
       top: 0;
     }

--- a/src/scss/components/product-grid.scss
+++ b/src/scss/components/product-grid.scss
@@ -5,7 +5,15 @@
   gap: 6px;
   height: 100%;
 
+  @include media('md-up') {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
   @include media('lg-up') {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include media('xxl-up') {
     grid-template-columns: repeat(6, 1fr);
   }
 


### PR DESCRIPTION
- [x] Speaker icon jumps into the logo grid on smaller screens
- [x] Add soft glow to logo quadrant
- [x] All logos should be at most 85% of their current size. Light, Index, Sanctu, and XXIX logos should be smaller still (try 70%).
- [x] Logos too big at mid screensize
- [x] Easing on the shimmer "DM hugh..." is buggy on smaller screens. Should be a consistent speed, bonus points if you can make it flicker a little : )
- [x] Favicon should start with the correct color
- [x] Hydro & Light logo SVGs don't show on iOS Chrome